### PR TITLE
remove deprecated Buffer constructor from test

### DIFF
--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -19,7 +19,7 @@ describe('Yearly pagination', () => {
         files = {
             'blog.md': {
                 paginate: 'posts',
-                sidebar: new Buffer("I'm a sidebar content"),
+                sidebar: Buffer.from("I'm a sidebar content"),
             }
         };
 


### PR DESCRIPTION
Switch from `new Buffer()` to `Buffer.from()` in test to eliminate
deprecation warning when running tests in newer versions of Node.js.